### PR TITLE
EUI 0.0.53 no longer closes combo box when clear btn is pressed

### DIFF
--- a/test/functional/apps/visualize/_input_control_vis.js
+++ b/test/functional/apps/visualize/_input_control_vis.js
@@ -183,7 +183,7 @@ export default function ({ getService, getPageObjects }) {
         });
       });
 
-      describe('nested controls', () => {
+      describe('chained controls', () => {
 
         before(async () => {
           await PageObjects.common.navigateToUrl('visualize', 'new');

--- a/test/functional/page_objects/visualize_page.js
+++ b/test/functional/page_objects/visualize_page.js
@@ -261,14 +261,15 @@ export function VisualizePageProvider({ getService, getPageObjects }) {
 
     async clearComboBox(comboBoxSelector) {
       const comboBox = await testSubjects.find(comboBoxSelector);
-      const clearBtn = await comboBox.findByCssSelector('button.euiFormControlLayoutClearButton');
+      const clearBtn = await comboBox.findByCssSelector('[data-test-subj="comboBoxClearButton"]');
       await clearBtn.click();
+      await this.closeComboBoxOptionsList(comboBox);
     }
 
     async closeComboBoxOptionsList(comboBoxElement) {
       const isOptionsListOpen = await testSubjects.exists('comboBoxOptionsList');
       if (isOptionsListOpen) {
-        const closeBtn = await comboBoxElement.findByCssSelector('button.euiFormControlLayoutCustomIcon');
+        const closeBtn = await comboBoxElement.findByCssSelector('[data-test-subj="comboBoxToggleListButton"]');
         await closeBtn.click();
       }
     }


### PR DESCRIPTION
EUI 0.0.53 also added data-test-subj on the combo box buttons so CSS selectors are no longer needed